### PR TITLE
chore: Update Chainflip API endpoints to use mainnet archive URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "winbit32",
-  "version": "1.5.3",
+  "version": "1.5.3f",
   "private": false,
   "homepage": "https://winbit32.com",
   "dependencies": {

--- a/src/components/contexts/SKClientProviderManager.js
+++ b/src/components/contexts/SKClientProviderManager.js
@@ -468,8 +468,8 @@ export const SKClientProviderManager = ({ children }) => {
 				...phantomWallet,
 			},
 			rpcUrls: {
-					Chainflip: "https://chainflip.winbit32.com",
-					FLIP: "https://chainflip.winbit32.com",
+					Chainflip: "wss://mainnet-archive.chainflip.io",
+					FLIP: "wss://mainnet-archive.chainflip.io",
 					Ethereum: "https://mainnet.infura.io/v3/c3b4e673639742a89bbddcb49895d568",
 					ETH: "https://api-ethereum-mainnet.n.dwellir.com/204dd906-d81d-45b4-8bfa-6f5cc7163dbc",
 					AVAX: "https://avalanche-mainnet.infura.io/v3/c3b4e673639742a89bbddcb49895d568",

--- a/src/components/wallets/secureKeystore/secureKeystoreWallet.ts
+++ b/src/components/wallets/secureKeystore/secureKeystoreWallet.ts
@@ -389,7 +389,7 @@ const getWalletMethodsForChain = async ({
 
 			toolbox = await getToolboxByChainSubstrate(chain, {
 				signer,
-				providerUrl: chain === Chain.Polkadot ? RPCUrl.Polkadot : "wss://api-chainflip.n.dwellir.com/204dd906-d81d-45b4-8bfa-6f5cc7163dbc" as RPCUrl,
+				providerUrl: chain === Chain.Polkadot ? RPCUrl.Polkadot : "wss://mainnet-archive.chainflip.io" as RPCUrl,
 			});
 
 			address = signer.address;

--- a/src/components/win/programs.js
+++ b/src/components/win/programs.js
@@ -136,15 +136,15 @@ export const getPrograms = () => {
 					invisibleToHash: true,
 					unCloseable: true,
 					programs: [
-						{
-							progID: 8,
-							title: "Rare Sats",
-							icon: "💎", // Example ico
-							progName: "raresats.exe",
-							component: RareSats,
-							initialPosition: { x: 1, y: 1, width: 425, height: 485 },
-							maximised: true,
-						},
+						// {
+						// 	progID: 8,
+						// 	title: "Rare Sats",
+						// 	icon: "💎", // Example ico
+						// 	progName: "raresats.exe",
+						// 	component: RareSats,
+						// 	initialPosition: { x: 1, y: 1, width: 425, height: 485 },
+						// 	maximised: true,
+						// },
 
 						{
 							progID: 6,

--- a/src/services/client.js
+++ b/src/services/client.js
@@ -61,8 +61,8 @@ export const createSwapKitClient = async (key, api) => {
 				...phantomWallet,
 			},
 			rpcUrls: {
-				Chainflip: "wss://api-chainflip.n.dwellir.com/204dd906-d81d-45b4-8bfa-6f5cc7163dbc",
-				FLIP: "wss://api-chainflip.n.dwellir.com/204dd906-d81d-45b4-8bfa-6f5cc7163dbc",
+				Chainflip: "wss://mainnet-archive.chainflip.io",
+				FLIP: "wss://mainnet-archive.chainflip.io",
 				Ethereum: "https://mainnet.infura.io/v3/c3b4e673639742a89bbddcb49895d568",
 				ETH: "https://api-ethereum-mainnet.n.dwellir.com/204dd906-d81d-45b4-8bfa-6f5cc7163dbc",
 				AVAX: "https://avalanche-mainnet.infura.io/v3/c3b4e673639742a89bbddcb49895d568",


### PR DESCRIPTION
This commit updates the Chainflip API endpoints in SKClientProviderManager.js, client.js, and secureKeystoreWallet.ts to use the new mainnet archive URLs for improved reliability. Additionally, commented out the Rare Sats program in programs.js for future reference. These changes aim to enhance the robustness and maintainability of the codebase.